### PR TITLE
CRNCC-2299 - Reduce ECS instance count to 1 to prevent duplicate emails being sent by the notification service.

### DIFF
--- a/global.tf
+++ b/global.tf
@@ -136,7 +136,7 @@ variable "names" {
       "log_types" = ["error", "general", "slowquery", "audit"]
       "publicly_accessible"   = true
       "add_scheduler_tag"     = true
-      "ecs_instance_count"    = 3
+      "ecs_instance_count"    = 1
       "waf_create"            = "true"
       "whitelist_ips" = ["0.0.0.0/0"]
       "ecs_cpu"               = 1024
@@ -171,7 +171,7 @@ variable "names" {
       "log_types" = ["error", "general", "slowquery", "audit"]
       "publicly_accessible"   = true
       "add_scheduler_tag"     = false
-      "ecs_instance_count"    = 3
+      "ecs_instance_count"    = 1
       "waf_create"            = "true"
       "whitelist_ips" = ["0.0.0.0/0"]
       "ecs_cpu"               = 1024


### PR DESCRIPTION
Running 3 containers on RMS had the unexpected impact of Notify being sent email requests 3 times per individual notification, due to the task checking for unprocessed notifications running 3 times. 

As a temporary fix, we have scaled down to just 1 container and this is ensuring only one email is sent to Notify. 

However, the terraform code is likely going to reset this if not changed, and while 3 containers may not be needed now, if we go back up to 2 or 3 in the future we need to ensure this issue does not re-occur. 

https://nihr.atlassian.net/browse/CRNCC-2299