### PR TITLE
RMS ECS Schedule Update for OAT and Start Time

### DIFF
--- a/modules/autoscaling_group/main.tf
+++ b/modules/autoscaling_group/main.tf
@@ -12,7 +12,7 @@ resource "aws_appautoscaling_target" "my_service" {
     ]
   }
 }
-resource "aws_appautoscaling_scheduled_action" "my_service" {
+resource "aws_appautoscaling_scheduled_action" "my_service_scale_down" {
   count              = var.env == "prod" ? 0 : 1
   name               = "${var.account}-asg-${var.env}-${var.system}-${var.app}-scale-down"
   service_namespace  = aws_appautoscaling_target.my_service[0].service_namespace
@@ -26,7 +26,7 @@ resource "aws_appautoscaling_scheduled_action" "my_service" {
     max_capacity = 0
   }
 }
-resource "aws_appautoscaling_scheduled_action" "my_service_scale_out" {
+resource "aws_appautoscaling_scheduled_action" "my_service_scale_up" {
   count              = var.env == "prod" ? 0 : 1
   name               = "${var.account}-asg-${var.env}-${var.system}-${var.app}-scale-up"
   service_namespace  = aws_appautoscaling_target.my_service[0].service_namespace

--- a/modules/autoscaling_group/main.tf
+++ b/modules/autoscaling_group/main.tf
@@ -1,5 +1,5 @@
 resource "aws_appautoscaling_target" "my_service" {
-  count              = var.env == "oat" || var.env == "prod" ? 0 : 1
+  count              = var.env == "prod" ? 0 : 1
   max_capacity       = 1
   min_capacity       = 1
   resource_id        = "service/${var.account}-ecs-${var.env}-${var.system}-${var.app}-cluster/${var.account}-ecs-${var.env}-${var.system}-${var.app}-service"
@@ -13,7 +13,7 @@ resource "aws_appautoscaling_target" "my_service" {
   }
 }
 resource "aws_appautoscaling_scheduled_action" "my_service" {
-  count              = var.env == "oat" || var.env == "prod" ? 0 : 1
+  count              = var.env == "prod" ? 0 : 1
   name               = "${var.account}-asg-${var.env}-${var.system}-${var.app}-scale-down"
   service_namespace  = aws_appautoscaling_target.my_service[0].service_namespace
   resource_id        = aws_appautoscaling_target.my_service[0].resource_id
@@ -27,12 +27,12 @@ resource "aws_appautoscaling_scheduled_action" "my_service" {
   }
 }
 resource "aws_appautoscaling_scheduled_action" "my_service_scale_out" {
-  count              = var.env == "oat" || var.env == "prod" ? 0 : 1
+  count              = var.env == "prod" ? 0 : 1
   name               = "${var.account}-asg-${var.env}-${var.system}-${var.app}-scale-up"
   service_namespace  = aws_appautoscaling_target.my_service[0].service_namespace
   resource_id        = aws_appautoscaling_target.my_service[0].resource_id
   scalable_dimension = aws_appautoscaling_target.my_service[0].scalable_dimension
-  schedule           = "cron(0 6 ? * MON-FRI *)"
+  schedule           = "cron(0 7 ? * MON-FRI *)"
   timezone           = "Europe/London"
 
   scalable_target_action {


### PR DESCRIPTION
The RMS OAT ECS tasks are running 24/7, despite the RDS instance and other parts of the system being scheduled. This causes the tasks to failover generating unnecessary AWS Config recordings and keeps tasks running when they don’t need to be. This is to update the infrastructure terraform to include a scaling action for oat to keep this optimal.

We will also adjust the start up time from 06:00 to 07:00 to align to other systems.